### PR TITLE
Contract fixes

### DIFF
--- a/contract/contracts/WanderersPass.sol
+++ b/contract/contracts/WanderersPass.sol
@@ -58,12 +58,18 @@ contract WanderersPass is ERC721, ERC721Enumerable, Ownable, Pausable {
         planetContract = _planetContract;
     }
 
-    function setPassName(uint256 id, string calldata _passName) external whenNotPaused {
+    function setPassName(uint256 id, string calldata _passName)
+        external
+        whenNotPaused
+    {
         require(msg.sender == ownerOf(id), "Not owner of pass");
         passName[id] = _passName;
     }
 
-    function safeMint(address to, string calldata _passName) external whenNotPaused {
+    function safeMint(address to, string calldata _passName)
+        external
+        whenNotPaused
+    {
         passName[_tokenIdCounter.current()] = _passName;
         _safeMint(to, _tokenIdCounter.current());
         _tokenIdCounter.increment();
@@ -124,6 +130,20 @@ contract WanderersPass is ERC721, ERC721Enumerable, Ownable, Pausable {
                 planetContract.planetState(planetId)
             );
         }
+    }
+
+    function tokensOfOwner(address owner)
+        external
+        view
+        returns (uint256[] memory)
+    {
+        uint256[] memory tokens = new uint256[](balanceOf(owner));
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            tokens[i] = tokenOfOwnerByIndex(owner, i);
+        }
+
+        return tokens;
     }
 
     // The following functions are overrides required by Solidity.

--- a/contract/contracts/WanderersPass.sol
+++ b/contract/contracts/WanderersPass.sol
@@ -11,24 +11,31 @@ import "./WanderersPlanet.sol";
 contract WanderersPass is ERC721, ERC721Enumerable, Ownable, Pausable {
     using Counters for Counters.Counter;
 
+    /// A strictly monotonically increasing counter of token IDs.
     Counters.Counter private _tokenIdCounter;
 
-    // Mapping of ID to names
+    /// Mapping of Passes to names.
     mapping(uint256 => string) public passName;
 
-    // Struct containing a single stamp.
+    /// The contents of a single stamp.
     struct PassStamp {
+        /// Token ID of Planet
         uint256 planetId;
+        /// State of planet at time to stamping
         uint256 state;
     }
 
-    // Mapping of ID to an array of stamps
+    /// Mapping of Passes to array of stamps
     mapping(uint256 => PassStamp[]) private stamps;
 
-    // Planet contract
+    /// Location of Planet contract
     WanderersPlanet public planetContract;
 
-    // Event emitted when a stamp occurs
+    /// Event emitted when a stamp occurs
+    /// @param from address which initiated the stamp
+    /// @param passId the Pass that was stamped
+    /// @param planetId the Planet that was stamped
+    /// @param planetState the state of the Planet at the time of stamping
     event Stamp(
         address indexed from,
         uint256 indexed passId,
@@ -43,14 +50,18 @@ contract WanderersPass is ERC721, ERC721Enumerable, Ownable, Pausable {
         _pause();
     }
 
+    /// Pauses the contract.
     function pause() external onlyOwner {
         _pause();
     }
 
+    /// Unpauses the contract.
     function unpause() external onlyOwner {
         _unpause();
     }
 
+    /// Updates the location of the Planet contract.
+    /// @param _planetContract the new location of the Planet contract
     function updatePlanetContract(WanderersPlanet _planetContract)
         external
         onlyOwner
@@ -58,6 +69,9 @@ contract WanderersPass is ERC721, ERC721Enumerable, Ownable, Pausable {
         planetContract = _planetContract;
     }
 
+    /// Set the name of a Pass.
+    /// @param id the token ID of the Pass
+    /// @param _passName the new name of the Pass
     function setPassName(uint256 id, string calldata _passName)
         external
         whenNotPaused
@@ -66,6 +80,9 @@ contract WanderersPass is ERC721, ERC721Enumerable, Ownable, Pausable {
         passName[id] = _passName;
     }
 
+    /// Mint a new Pass.
+    /// @param to the address to send the Pass to
+    /// @param _passName the name for the Pass
     function safeMint(address to, string calldata _passName)
         external
         whenNotPaused
@@ -75,6 +92,9 @@ contract WanderersPass is ERC721, ERC721Enumerable, Ownable, Pausable {
         _tokenIdCounter.increment();
     }
 
+    /// @dev create a PassStamp struct
+    /// @param planetId the token ID of the Planet
+    /// @return a PassStamp struct
     function makePassStamp(uint256 planetId)
         internal
         view
@@ -83,10 +103,16 @@ contract WanderersPass is ERC721, ERC721Enumerable, Ownable, Pausable {
         return PassStamp(planetId, planetContract.planetState(planetId));
     }
 
+    /// Gets all stamps of a Pass
+    /// @param id the token ID of the Pass
+    /// @return an array of all stamps 
     function getStamps(uint256 id) external view returns (PassStamp[] memory) {
         return stamps[id];
     }
 
+    /// Visit a planet
+    /// @param id the token ID of the Pass
+    /// @param planetId the token ID of the Planet to visit
     function visitPlanet(uint256 id, uint256 planetId) external whenNotPaused {
         // Make sure planet is owned by sender
         require(
@@ -106,32 +132,39 @@ contract WanderersPass is ERC721, ERC721Enumerable, Ownable, Pausable {
         );
     }
 
-    function visitPlanet(uint256 id, uint256[] calldata planetIds)
+
+    /// Visit multiple Planets
+    /// @param id the token ID of the Pass
+    /// @param planetId an array of IDs of Planets to visit
+    function visitPlanet(uint256 id, uint256[] calldata planetId)
         external
         whenNotPaused
     {
         // Make sure pass is owned by sender
         require(ownerOf(id) == msg.sender, "Not owner of pass");
 
-        for (uint256 i = 0; i < planetIds.length; i++) {
+        for (uint256 i = 0; i < planetId.length; i++) {
             // Make sure planet is owned by sender
             require(
-                planetContract.ownerOf(planetIds[i]) == msg.sender,
+                planetContract.ownerOf(planetId[i]) == msg.sender,
                 "Not owner of planet"
             );
-            uint256 planetId = planetIds[i];
+            uint256 _planetId = planetId[i];
 
-            stamps[id].push(makePassStamp(planetId));
+            stamps[id].push(makePassStamp(_planetId));
 
             emit Stamp(
                 msg.sender,
                 id,
-                planetId,
-                planetContract.planetState(planetId)
+                _planetId,
+                planetContract.planetState(_planetId)
             );
         }
     }
 
+    /// Return the tokens owned by a owner
+    /// @param owner the owner address
+    /// @return an array of all tokens owned by the address
     function tokensOfOwner(address owner)
         external
         view

--- a/contract/contracts/WanderersPlanet.sol
+++ b/contract/contracts/WanderersPlanet.sol
@@ -129,6 +129,20 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         }
     }
 
+    function tokensOfOwner(address owner)
+        external
+        view
+        returns (uint256[] memory)
+    {
+        uint256[] memory tokens = new uint256[](balanceOf(owner));
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            tokens[i] = tokenOfOwnerByIndex(owner, i);
+        }
+
+        return tokens;
+    }
+
     // The following functions are overrides required by Solidity.
 
     function _beforeTokenTransfer(

--- a/contract/contracts/WanderersPlanet.sol
+++ b/contract/contracts/WanderersPlanet.sol
@@ -7,8 +7,11 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
 
 contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
+    using Strings for uint256;
+
     string private baseURI;
     bytes32 public immutable root;
 
@@ -141,6 +144,22 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         }
 
         return tokens;
+    }
+
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
+        return
+            string(
+                abi.encodePacked(
+                    super.tokenURI(tokenId),
+                    "/",
+                    planetState[tokenId].toString()
+                )
+            );
     }
 
     // The following functions are overrides required by Solidity.

--- a/contract/contracts/WanderersPlanet.sol
+++ b/contract/contracts/WanderersPlanet.sol
@@ -152,13 +152,17 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         override
         returns (string memory)
     {
+        return tokenURIWithState(tokenId, planetState[tokenId]);
+    }
+
+    function tokenURIWithState(uint256 tokenId, uint256 state)
+        public
+        view
+        returns (string memory)
+    {
         return
             string(
-                abi.encodePacked(
-                    super.tokenURI(tokenId),
-                    "/",
-                    planetState[tokenId].toString()
-                )
+                abi.encodePacked(super.tokenURI(tokenId), "/", state.toString())
             );
     }
 

--- a/contract/contracts/WanderersPlanet.sol
+++ b/contract/contracts/WanderersPlanet.sol
@@ -12,16 +12,19 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
     using Strings for uint256;
 
+    /// Base URI for metadata
     string private baseURI;
+
+    /// Root of merkle tree used for airdrop
     bytes32 public immutable root;
 
-    // Claiming enabled or disabled
+    /// Claiming enabled or disabled
     bool public claimEnabled;
 
-    // Current planet state (see internal docs for what they represent)
+    /// Mapping of Planets to states (see internal docs for what they represent)
     mapping(uint256 => uint256) public planetState;
 
-    // Current planet names
+    /// Mapping of Planets to names
     mapping(uint256 => string) public planetNames;
 
     constructor(string memory baseURI_, bytes32 _root)
@@ -33,31 +36,42 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         _pause();
     }
 
+    /// Pauses the contract.
     function pause() external onlyOwner {
         _pause();
     }
 
+    /// Unpauses the contract.
     function unpause() external onlyOwner {
         _unpause();
     }
 
+    /// @dev override for base URI
+    /// @return the variable `baseURI`
     function _baseURI() internal view override returns (string memory) {
         return baseURI;
     }
 
+    /// Updates the base URI.
+    /// @param newBaseURI the new base URI to be used
     function updateBaseURI(string calldata newBaseURI) external onlyOwner {
         baseURI = newBaseURI;
     }
 
+    /// Enables the airdrop claim functionality.
     function enableClaim() external onlyOwner {
         claimEnabled = true;
     }
 
+    /// Disables the airdrop claim functionality.
     function disableClaim() external onlyOwner {
         claimEnabled = false;
     }
 
-    // Claim planets according to merkle proof
+    /// Claim a Planet according to merkle proof.
+    /// @param to the address to send the Planet to
+    /// @param id the token ID of the Planet being claimed
+    /// @param proof the merkle tree proof that the sender is entitled to the Planet
     function claim(
         address to,
         uint256 id,
@@ -71,6 +85,10 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         _safeMint(to, id);
     }
 
+    /// @dev reconstructs the leaf hash of a claim
+    /// @param id the token ID of the leaf
+    /// @param account the account of the leaf
+    /// @return hash of the leaf
     function _leaf(uint256 id, address account)
         internal
         pure
@@ -79,6 +97,10 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         return keccak256(abi.encodePacked(id, account));
     }
 
+    /// @dev verifies if the leaf can be proven to be part of the merkle tree defined by `root`.
+    /// @param leaf the leaf to prove
+    /// @param proof the proof that the leaf is part of the tree
+    /// @return whether the leaf is part of the tree
     function _verify(bytes32 leaf, bytes32[] memory proof)
         internal
         view
@@ -87,6 +109,9 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         return MerkleProof.verify(proof, root, leaf);
     }
 
+    /// Set then name of a Planet.
+    /// @param id the token ID of the Planet
+    /// @param name the new name of the Planet
     function setPlanetName(uint256 id, string calldata name)
         external
         whenNotPaused
@@ -95,6 +120,9 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         planetNames[id] = name;
     }
 
+    /// Set then name of Planets.
+    /// @param id an array token IDs of Planets
+    /// @param name an array of new names for the Planets
     function setPlanetName(uint256[] calldata id, string[] calldata name)
         external
         whenNotPaused
@@ -106,23 +134,32 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         }
     }
 
-    // Owner can mint more
+    /// Mint a Planet. Tokens 0-8887 inclusive are reserved for the airdrop.
+    /// @param to the address to send the Planet to
+    /// @param id the token ID of the Planet to mint
     function safeMint(address to, uint256 id) external onlyOwner {
         _safeMint(to, id);
     }
 
+    /// Mint Planets. Tokens 0-8887 inclusive are reserved for the airdrop.
+    /// @param to the address to send the Planet to
+    /// @param id an array of token IDs of Planets to mint
     function safeMint(address to, uint256[] calldata id) external onlyOwner {
         for (uint256 i = 0; i < id.length; i++) {
             _safeMint(to, id[i]);
         }
     }
 
-    // Update state for one planet
+    /// Update the state of a Planet.
+    /// @param id the token ID of the Planet
+    /// @param state the state to update to
     function setPlanetState(uint256 id, uint256 state) external onlyOwner {
         planetState[id] = state;
     }
 
-    // Update state for multiple planets
+    /// Update the states of Planets.
+    /// @param id the token ID of the Planet
+    /// @param state the state to update to
     function setPlanetState(uint256[] calldata id, uint256 state)
         external
         onlyOwner
@@ -132,6 +169,9 @@ contract WanderersPlanet is ERC721, ERC721Enumerable, Ownable, Pausable {
         }
     }
 
+    /// Return the tokens owned by a owner
+    /// @param owner the owner address
+    /// @return an array of all tokens owned by the address
     function tokensOfOwner(address owner)
         external
         view

--- a/contract/test/test-pass.ts
+++ b/contract/test/test-pass.ts
@@ -248,4 +248,22 @@ describe("WanderersPass", function () {
             expect(await pass.planetContract()).to.equal(planetsTwo.address);
         })
     });
+
+    describe("tokensOfOwner", function () {
+        beforeEach(async function () {
+            if (await pass.paused()) {
+                await pass.unpause();
+            }
+        });
+
+        it("should be able to enumerate all Passes of an owner", async function () {
+            const address = await accounts[0].getAddress();
+            await pass.connect(accounts[0]).safeMint(address, "Test");
+            await pass.connect(accounts[0]).safeMint(address, "Test");
+            await pass.connect(accounts[0]).safeMint(address, "Test");
+
+            const numberOfPasses = await pass.tokensOfOwner(address);
+            expect(numberOfPasses.length).to.equal(3);
+        });
+    });
 })

--- a/contract/test/test-planet.ts
+++ b/contract/test/test-planet.ts
@@ -134,14 +134,27 @@ describe("WanderersPlanet", function () {
 
             await planets.connect(accounts[0]).claim(
                 address,
-                0,
-                merkleTree.getHexProof(hash(0, address))
+                1,
+                merkleTree.getHexProof(hash(1, address))
             );
 
-            expect(await planets.tokenURI(0)).to.equal("example.com/0");
+            expect(await planets.tokenURI(1)).to.equal("example.com/1/0");
         });
 
         it("should be able to change uri", async function () {
+            const address = await accounts[0].getAddress();
+
+            await planets.connect(accounts[0]).claim(
+                address,
+                1,
+                merkleTree.getHexProof(hash(1, address))
+            );
+
+            await planets.connect(accounts[0]).updateBaseURI("emmy.org/");
+            expect(await planets.tokenURI(1)).to.equal("emmy.org/1/0");
+        });
+
+        it("should work with different states", async function () {
             const address = await accounts[0].getAddress();
 
             await planets.connect(accounts[0]).claim(
@@ -150,8 +163,24 @@ describe("WanderersPlanet", function () {
                 merkleTree.getHexProof(hash(0, address))
             );
 
+            await planets.connect(accounts[0])['setPlanetState(uint256,uint256)'](0, 1);
+
+            expect(await planets.tokenURI(0)).to.equal("example.com/0/1");
+        });
+
+        it("should work with different states after baseURI change", async function () {
+            const address = await accounts[0].getAddress();
+
+            await planets.connect(accounts[0]).claim(
+                address,
+                0,
+                merkleTree.getHexProof(hash(0, address))
+            );
+
+            await planets.connect(accounts[0])['setPlanetState(uint256,uint256)'](0, 1);
+
             await planets.connect(accounts[0]).updateBaseURI("emmy.org/");
-            expect(await planets.tokenURI(0)).to.equal("emmy.org/0");
+            expect(await planets.tokenURI(0)).to.equal("emmy.org/0/1");
         });
     });
 

--- a/contract/test/test-planet.ts
+++ b/contract/test/test-planet.ts
@@ -249,7 +249,7 @@ describe("WanderersPlanet", function () {
             const address = await accounts[0].getAddress();
             tokensToMint = [...Array(25).keys()];
 
-            await planets.connect(accounts[0])['safeMint(address,uint256[])'](address, tokensToMint); 
+            await planets.connect(accounts[0])['safeMint(address,uint256[])'](address, tokensToMint);
         });
 
         it("owner should be able to rename Planet", async function () {
@@ -270,14 +270,32 @@ describe("WanderersPlanet", function () {
             await expect(
                 planets.connect(accounts[1])['setPlanetName(uint256[],string[])'](tokensToMint, names)
             )
-            .to.be.revertedWith("Not owner of Planet");
+                .to.be.revertedWith("Not owner of Planet");
         });
 
         it("non-owner should not be able to rename Planet", async function () {
             await expect(
                 planets.connect(accounts[1])['setPlanetName(uint256,string)'](0, newName)
             )
-            .to.be.revertedWith("Not owner of Planet");
+                .to.be.revertedWith("Not owner of Planet");
+        });
+    });
+
+    describe("tokensOfOwner", function () {
+        beforeEach(async function () {
+            if (await planets.paused()) {
+                await planets.unpause();
+            }
+        });
+
+        it("should be able to enumerate all Planets of an owner", async function () {
+            const address = await accounts[0].getAddress();
+            const tokensToMint = [...Array(30).keys()];
+
+            await planets.connect(accounts[0])['safeMint(address,uint256[])'](address, tokensToMint);
+
+            const numberOfPlanets = await planets.tokensOfOwner(address);
+            expect(numberOfPlanets.length).to.equal(30);
         });
     });
 });


### PR DESCRIPTION
- Implement `tokensOfOwner` view function that returns all tokens of an address
- Update `tokenURI` to consider planet state as well (`baseURI/tokenId/planetState`)
- Add `tokenURIWithState` that allows for a passed-in state number. Useful for stamps.